### PR TITLE
Add conversion offline mode

### DIFF
--- a/curl_env_vars.sh
+++ b/curl_env_vars.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-export API_VERSION="11";
+export API_VERSION="13";
 export CLIENT_ID="< from the json >";
 export CLIENT_SECRET="< from the json >";
 export DEVELOPER_TOKEN="< fro mthe UI >";
@@ -7,3 +7,4 @@ export OAUTH2_ACCESS_TOKEN="< from the refresh token call >";
 export MANAGER_CUSTOMER_ID="<from the UI, left corner >";
 export CUSTOMER_ID="<from the UI, id on the right>";
 export REFRESH_TOKEN="< upon authentication >"
+export ACTION_CONVERSION_ID="< from the UI >";

--- a/curl_send_call_conversion_offline.sh
+++ b/curl_send_call_conversion_offline.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+echo "https://googleads.googleapis.com/v${API_VERSION}/customers:listAccessibleCustomers"
+echo "Authorization: Bearer ${OAUTH2_ACCESS_TOKEN}"
+
+# https://developers.google.com/google-ads/api/reference/rpc/v13/UploadCallConversionsRequest
+curl -f -i -v "https://googleads.googleapis.com/v${API_VERSION}/customers/${CUSTOMER_ID}:uploadCallConversions" \
+--header "Content-Type: application/json" \
+--header "developer-token: ${DEVELOPER_TOKEN}" \
+--header "login-customer-id: ${MANAGER_CUSTOMER_ID}" \
+--header "Authorization: Bearer ${OAUTH2_ACCESS_TOKEN}" https://googleads.googleapis.com/v13/customers/7529408212:uploadCallConversions \
+--data "{
+    'conversions': [
+        {
+            'conversionAction': 'customers/${CUSTOMER_ID}/conversionActions/${ACTION_CONVERSION_ID}',
+            'callerId': '+34600000000',
+            'callStartDateTime': '2023-03-30 19:09:25+02:00',
+            'conversionDateTime': '2023-03-30 20:05:10+01:00',
+            'conversionValue': 10,
+            'currencyCode': 'EUR'
+        }
+    ],
+    'partialFailure': true
+}"

--- a/curl_send_click_conversion_offline.sh
+++ b/curl_send_click_conversion_offline.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+echo "https://googleads.googleapis.com/v${API_VERSION}/customers:listAccessibleCustomers"
+echo "Authorization: Bearer ${OAUTH2_ACCESS_TOKEN}"
+
+# https://developers.google.com/google-ads/api/reference/rpc/v13/UploadClickConversionsRequest
+curl -f -i -v "https://googleads.googleapis.com/v${API_VERSION}/customers/${CUSTOMER_ID}:uploadCallConversions" \
+--header "Content-Type: application/json" \
+--header "developer-token: ${DEVELOPER_TOKEN}" \
+--header "login-customer-id: ${MANAGER_CUSTOMER_ID}" \
+--header "Authorization: Bearer ${OAUTH2_ACCESS_TOKEN}" https://googleads.googleapis.com/v13/customers/7529408212:uploadCallConversions \
+--data "{
+    'conversions': [
+        {
+            'conversionAction': 'customers/${CUSTOMER_ID}/conversionActions/${ACTION_CONVERSION_ID}',
+            'gclid': 'EJr-AYWtJ7ICFQzazAod22kB9w',
+            'conversionDateTime': '2023-03-30 20:05:10+01:00',
+            'conversionValue': 10,
+            'currencyCode': 'EUR'
+        }
+    ],
+    'partialFailure': true
+}"


### PR DESCRIPTION
I would like to add offline conversions to your repository a practical way to send customer statuses for both click and call inbound

https://developers.google.com/google-ads/api/reference/rpc/v13/UploadClickConversionsRequest
https://developers.google.com/google-ads/api/reference/rpc/v13/UploadCallConversionsRequest